### PR TITLE
bugfix: macros.py should not be included in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include configure.ac Makefile README.first *.md *.txt
 recursive-include procszoo/c_functions *.in *.h
+exclude procszoo/c_functions/macros.py


### PR DESCRIPTION
After `macros.py` being generated, running `./setup.py sdist` will include `macros.py` in the sdist.
Hence, we should exclude `macros.py` in `MANIFEST.in` explicitly.
Note that this issue doesn't affect the released v0.1.1 on PyPI, because I didn't run `./configure` before uploading -_-! 