### PR TITLE
add rpm spec

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include configure.ac Makefile README.first *.md *.txt VERSION
+include configure.ac Makefile README.first *.md *.txt VERSION *.spec
 recursive-include procszoo *.in *.h
 exclude procszoo/c_functions/macros.py procszoo/version.py
 

--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,27 @@ configure: configure.ac
 $(CONFIGURE_OUT): configure $(CONFIGURE_OUT:%=%.in)
 	$(Q)./configure
 
-.PHONY: all clean build_ext prepare
+# Packaging
+VERSION := $(shell tr -d '\n' < VERSION)
+
+dist:
+	$(Q)$(PYTHON) ./setup.py sdist
+
+RPMBUILD_TOPDIR := build/rpmbuild
+RPM_OUTDIR := dist
+SRPM_OUTDIR := dist
+
+srpm: dist
+	$(Q)cp VERSION dist/VERSION
+	$(Q)mkdir -p "$(RPMBUILD_TOPDIR)" "$(SRPM_OUTDIR)"
+	$(Q)rpmbuild --define "_topdir $(shell pwd)/$(RPMBUILD_TOPDIR)" --clean -ts "dist/procszoo-$(VERSION).tar.gz"
+	$(Q)cp -a "$(RPMBUILD_TOPDIR)"/SRPMS/*.rpm "$(SRPM_OUTDIR)"
+
+rpm: dist
+	$(Q)cp VERSION dist/VERSION
+	$(Q)mkdir -p "$(RPMBUILD_TOPDIR)" "$(RPM_OUTDIR)" "$(SRPM_OUTDIR)"
+	$(Q)rpmbuild --define "_topdir $(shell pwd)/$(RPMBUILD_TOPDIR)" --clean -ta "dist/procszoo-$(VERSION).tar.gz"
+	$(Q)cp -a "$(RPMBUILD_TOPDIR)"/{SRPMS,RPMS/*}/*.rpm "$(SRPM_OUTDIR)"
+
+.PHONY: all clean build_ext prepare dist srpm rpm
 

--- a/procszoo.spec
+++ b/procszoo.spec
@@ -1,0 +1,160 @@
+%global srcname procszoo
+%global debug_package %{nil}
+SOURCE10: VERSION
+%global version %(tr -d '\n' < %{SOURCE10})
+%global release 1
+%global sum Python module to operate Linux namespaces
+%global desc Procszoo aims to provide you a simple but complete tool and you can use it \
+as a DSL or an embeded programming language which let you operate Linux namespaces by Python. \
+Procszoo gives a smart init program. I get it from baseimage-docker. \
+Thanks a lot, you guys. \
+Procszoo does not require new version Python (but we support python3, too) and Linux kernel.
+
+Name: python-%{srcname}
+Summary: %{sum}
+Version: %{version}
+Release: %{release}%{?dist}
+Source: %{srcname}-%{version}.tar.gz
+License: GPL2+
+Group: Development/Libraries
+AutoReq: no
+Prefix: %{_prefix}
+Vendor: xning <anzhou94@gmail.com>
+Packager: Rayson Zhu <vfreex+procszoo@gmail.com>
+Url: https://github.com/xning/procszoo
+Requires(post): %{_sbindir}/update-alternatives
+Requires(postun): %{_sbindir}/update-alternatives
+BuildRequires: autoconf make gcc
+
+%global with_python2 1
+
+%if 0%{?rhel} >= 7 || 0%{?fedora} >= 13
+%global with_python3 1
+%endif
+
+%if 0%{?with_python2}
+%{!?python2_version: %global python2_version %(%{__python2} -c "import sys; sys.stdout.write('\%s.\%s' \% (sys.version_info[0], sys.version_info[1]))")}
+%if 0%{?rhel} <=7 || 0%{?fedora} <= 21
+%{!?python2_pkgversion: %global python2_pkgversion ''}
+%global python2_pkgprefix python
+%else
+%{!?python2_pkgversion: %global python2_pkgversion 2}
+%global python2_pkgprefix python2
+%endif    
+%endif
+
+%if 0%{?with_python3}
+%{!?python3_pkgversion: %global python3_pkgversion 3}
+%global python3_pkgprefix python%{python3_pkgversion}
+%endif
+
+%if 0%{?rhel}
+BuildRequires: epel-rpm-macros
+%endif 
+
+%if 0%{?with_python2}
+BuildRequires: %{python2_pkgprefix}-devel %{python2_pkgprefix}-setuptools python-rpm-macros python2-rpm-macros
+%endif
+
+%if 0%{?with_python3}
+BuildRequires: %{python3_pkgprefix}-devel %{python3_pkgprefix}-setuptools python3-pkgversion-macros python-rpm-macros python3-rpm-macros 
+%endif
+
+%description
+Procszoo aims to provide you a simple but complete tool and you can use it as a DSL or an embeded programming language which let you operate Linux namespaces by Python. Procszoo gives a smart init program. I get it from baseimage-docker. Thanks a lot, you guys. Procszoo does not require new version Python (but we support python3, too) and Linux kernel.
+
+%if 0%{?with_python2}
+%package -n python2-%{srcname}
+AutoReq: no
+Requires: python(abi) = %{python2_version} %{python2_pkgprefix}-setuptools
+Summary: %{sum}
+#%{?python_provide:%python_provide python2-%{srcname}}
+
+%description -n python2-%{srcname}
+%{desc}
+%endif
+
+%if 0%{?with_python3}
+%package -n python%{python3_pkgversion}-%{srcname} 
+AutoReq: no
+Requires: python(abi) = %{python3_version} python%{python3_pkgversion}-setuptools
+Summary: %{sum}
+#%{?python_provide:%python_provide python%{python3_pkgversion}-%{srcname}}
+
+%description -n python%{python3_pkgversion}-%{srcname}
+%{desc}
+%endif
+
+%prep
+%setup -n %{srcname}-%{version} -n %{srcname}-%{version}
+
+%build
+%if 0%{?with_python2}
+%py2_build
+%endif
+
+%if 0%{?with_python3}
+%py3_build
+%endif
+
+%install
+
+%if 0%{?with_python3}
+%py3_install
+%endif
+
+%if 0%{?with_python2}
+%py2_install
+%endif
+
+%clean
+rm -rf "$RPM_BUILD_ROOT"
+
+%if 0%{?with_python2}
+%files -n python2-%{srcname}
+%license LICENSE.txt
+%doc README.first
+%doc README.md
+%{python2_sitearch}/*
+%{_bindir}/setuid
+%{_bindir}/my_init
+%ghost %{_bindir}/richard_parker
+%{_bindir}/*-%{python2_version}
+%{_bindir}/*-2
+%endif
+
+%if 0%{?with_python3}
+%files -n python%{python3_pkgversion}-%{srcname}
+%license LICENSE.txt
+%doc README.first
+%doc README.md
+%{python3_sitearch}/*
+%{_bindir}/setuid
+%{_bindir}/my_init
+%ghost %{_bindir}/richard_parker
+%{_bindir}/*-%{python3_version}
+%{_bindir}/*-3
+%endif
+
+%if 0%{?with_python2}
+%post -n python2-%{srcname}
+%{_sbindir}/update-alternatives --install %{_bindir}/richard_parker \
+    richard_parker %{_bindir}/richard_parker-2 2
+
+%postun -n python2-%{srcname}
+if [ $1 -eq 0 ] ; then
+    %{_sbindir}/update-alternatives --remove richard_parker %{_bindir}/richard_parker-2
+fi
+%endif
+
+%if 0%{?with_python3}
+%post -n %{python3_pkgprefix}-%{srcname}
+%{_sbindir}/update-alternatives --install %{_bindir}/richard_parker \
+    richard_parker %{_bindir}/richard_parker-3 3
+
+%postun -n %{python3_pkgprefix}-%{srcname}
+if [ $1 -eq 0 ] ; then
+    %{_sbindir}/update-alternatives --remove richard_parker %{_bindir}/richard_parker-3
+fi
+%endif
+


### PR DESCRIPTION
@xning,
I finally get the job done. Please verify it with #37 .
We will use `alternates` to handle different versions of executable.
In another word, if a user only installs one version (python2 or python3 ) of procszoo, `/usr/bin/richard_parker` will be linked to `/usr/bin/richard_parker-X`. If a user installs both, `/usr/bin/richard_parker` will be linked to the python3 one.
See https://fedoraproject.org/wiki/PackagingDrafts/UsingAlternatives .